### PR TITLE
Small change to allow 3DS to be more easily loaded from MemoryStream.

### DIFF
--- a/lib3dsnet/lib3ds.cs
+++ b/lib3dsnet/lib3ds.cs
@@ -34,7 +34,7 @@ namespace lib3ds.Net
 	public class Lib3dsIo
 	{
 		internal int log_indent;
-		public FileStream self;
+		public Stream self;
 		public seek_func seek_func;
 		public tell_func tell_func;
 		public read_func read_func;

--- a/lib3dsnet/lib3ds_file.cs
+++ b/lib3dsnet/lib3ds_file.cs
@@ -68,25 +68,42 @@ namespace lib3ds.Net
 
 				try
 				{
-					Lib3dsIo io=new Lib3dsIo();
-					io.self=f;
-					io.seek_func=fileio_seek_func;
-					io.tell_func=fileio_tell_func;
-					io.read_func=fileio_read_func;
-					io.write_func=fileio_write_func;
-					io.log_func=log_func;
-
-					Lib3dsFile file=lib3ds_file_new();
-					if(file==null) return null;
-
-					if(!lib3ds_file_read(file, io)) return null;
-
-					return file;
+					return lib3ds_file_open(f, log_func);
 				}
 				finally
 				{
 					f.Close();
 				}
+			}
+			catch
+			{
+				return null;
+			}
+		}
+
+		public static Lib3dsFile lib3ds_file_open(Stream stream)
+		{
+			return lib3ds_file_open(stream, null);
+		}
+
+		public static Lib3dsFile lib3ds_file_open(Stream stream, log_func log_func)
+		{
+			try
+			{
+				Lib3dsIo io=new Lib3dsIo();
+				io.self=stream;
+				io.seek_func=fileio_seek_func;
+				io.tell_func=fileio_tell_func;
+				io.read_func=fileio_read_func;
+				io.write_func=fileio_write_func;
+				io.log_func=log_func;
+
+				Lib3dsFile file=lib3ds_file_new();
+				if(file==null) return null;
+
+				if(!lib3ds_file_read(file, io)) return null;
+
+				return file;
 			}
 			catch
 			{
@@ -870,7 +887,7 @@ namespace lib3ds.Net
 		public static Lib3dsMesh lib3ds_file_mesh_for_node(Lib3dsFile file, Lib3dsNode node)
 		{
 			if(node.type!=Lib3dsNodeType.LIB3DS_NODE_MESH_INSTANCE) return null;
-			Lib3dsMeshInstanceNode n=(Lib3dsMeshInstanceNode)node;
+			//Lib3dsMeshInstanceNode n=(Lib3dsMeshInstanceNode)node;
 			int index=lib3ds_file_mesh_by_name(file, node.name);
 			return (index>=0)?file.meshes[index]:null;
 		}


### PR DESCRIPTION
A tiny refactoring to generalize for loading from MemoryStream, e.g. to support web loading of 3DS models.

I have added:
`public static Lib3dsFile lib3ds_file_open(Stream stream)`
`public static Lib3dsFile lib3ds_file_open(Stream stream, log_func log_func)`

and I have changed the implementation of the functions below to call the functions above.
`public static Lib3dsFile lib3ds_file_open(string filename)`
`public static Lib3dsFile lib3ds_file_open(string filename, log_func log_func)`

the objective is to allow a call like:  `lib3ds_file_open(new MemoryStream(myByteArrayFromWeb));`
