### PR TITLE
Fix bug in the parsing of little endian integers.

### DIFF
--- a/lib3dsnet/lib3ds_io.cs
+++ b/lib3dsnet/lib3ds_io.cs
@@ -106,7 +106,7 @@ namespace lib3ds.Net
 			Debug.Assert(io!=null);
 			byte[] b=new byte[4];
 			lib3ds_io_read(io, b, 4);
-			return (uint)((b[3]<<23)|(b[2]<<16)|(b[1]<<8)|b[0]);
+			return (uint)((b[3]<<24)|(b[2]<<16)|(b[1]<<8)|b[0]);
 		}
 
 		// Read a signed byte from a file stream.
@@ -133,7 +133,7 @@ namespace lib3ds.Net
 			Debug.Assert(io!=null);
 			byte[] b=new byte[4];
 			lib3ds_io_read(io, b, 4);
-			return (int)((b[3]<<23)|(b[2]<<16)|(b[1]<<8)|b[0]);
+			return (int)((b[3]<<24)|(b[2]<<16)|(b[1]<<8)|b[0]);
 		}
 
 		// Read a float from a file stream in little endian format.


### PR DESCRIPTION
The C to C# port of the following two functions have typos causing failure to complete the loading of some 3DS files.

`static uint lib3ds_io_read_dword(Lib3dsIo io)`
`static int lib3ds_io_read_intd(Lib3dsIo io)`

i.e. The most significant byte in the integer should have been shifted by 24 bits, not 23.